### PR TITLE
gradle 설정 최적화, integrationTest task 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,33 +1,69 @@
-ext.config = [
-        group  : "com.github.galcyurio",
-        version: "0.0.1-SNAPSHOT"
-]
+buildscript {
+    ext.config = [
+            group  : "com.github.galcyurio",
+            version: "0.0.1-SNAPSHOT"
+    ]
 
-ext.versions = [
-        kotlin  : "1.2.40",
+    ext.versions = [
+            kotlin  : "1.2.40",
+            testSets: "1.4.5",
 
-        jackson : "2.9.5",
-        okhttp  : "3.10.0",
-        retrofit: "2.4.0",
+            jackson : "2.9.5",
+            okhttp  : "3.10.0",
+            retrofit: "2.4.0",
 
-        junit   : "4.12",
-        assertj : "3.9.0"
-]
+            junit   : "4.12",
+            assertj : "3.9.0"
+    ]
 
-ext.deps = [
-        kotlinStdLib            : "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}",
+    ext.deps = [
+            kotlinStdLib            : "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}",
 
-        jackson                 : "com.fasterxml.jackson.core:jackson-databind:${versions.jackson}",
-        jacksonModuleKotlin     : "com.fasterxml.jackson.module:jackson-module-kotlin:${versions.jackson}",
+            jackson                 : "com.fasterxml.jackson.core:jackson-databind:${versions.jackson}",
+            jacksonModuleKotlin     : "com.fasterxml.jackson.module:jackson-module-kotlin:${versions.jackson}",
 
-        okhttp                  : "com.squareup.okhttp3:okhttp:${versions.okhttp}",
-        retrofit                : "com.squareup.retrofit2:retrofit:${versions.retrofit}",
-        retrofitJacksonConverter: "com.squareup.retrofit2:converter-jackson:${versions.retrofit}",
+            okhttp                  : "com.squareup.okhttp3:okhttp:${versions.okhttp}",
+            retrofit                : "com.squareup.retrofit2:retrofit:${versions.retrofit}",
+            retrofitJacksonConverter: "com.squareup.retrofit2:converter-jackson:${versions.retrofit}",
 
-        junit                   : "junit:junit:${versions.junit}",
-        assertj                 : "org.assertj:assertj-core:${versions.assertj}",
-        okhttpMockWebServer     : "com.squareup.okhttp3:mockwebserver:${versions.okhttp}"
-]
+            junit                   : "junit:junit:${versions.junit}",
+            assertj                 : "org.assertj:assertj-core:${versions.assertj}",
+            okhttpMockWebServer     : "com.squareup.okhttp3:mockwebserver:${versions.okhttp}"
+    ]
+
+    repositories {
+        mavenCentral()
+        jcenter()
+    }
+
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
+        classpath "org.unbroken-dome.gradle-plugins:gradle-testsets-plugin:${versions.testSets}"
+    }
+}
 
 group config.group
 version config.version
+
+subprojects {
+    apply plugin: 'kotlin'
+
+    group = config.group
+    version = config.version
+
+    repositories {
+        mavenCentral()
+    }
+
+    dependencies {
+        testCompile deps.junit
+        testCompile deps.assertj
+    }
+
+    compileKotlin {
+        kotlinOptions.jvmTarget = "1.8"
+    }
+    compileTestKotlin {
+        kotlinOptions.jvmTarget = "1.8"
+    }
+}

--- a/sk-weather-planet-wrapper/build.gradle
+++ b/sk-weather-planet-wrapper/build.gradle
@@ -1,34 +1,5 @@
-group config.group
-version config.version
-
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${rootProject.ext.versions.kotlin}"
-    }
-}
-
-apply plugin: 'kotlin'
-
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     compile deps.kotlinStdLib
     compile deps.retrofit
     compile deps.retrofitJacksonConverter
-
-    /* Test */
-    testCompile deps.junit
-    testCompile deps.assertj
-}
-
-compileKotlin {
-    kotlinOptions.jvmTarget = "1.8"
-}
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.8"
 }

--- a/sk-weather-planet-wrapper/src/main/kotlin/com/github/galcyurio/weathor/sk/weatherplanet/support/Constants.kt
+++ b/sk-weather-planet-wrapper/src/main/kotlin/com/github/galcyurio/weathor/sk/weatherplanet/support/Constants.kt
@@ -3,4 +3,4 @@ package com.github.galcyurio.weathor.sk.weatherplanet.support
 /**
  * SK planet 서비스의 Location API 중 [Weather Planet](https://developers.sktelecom.com/content/sktApi/view/?svcId=10113)의 `baseUrl`이다.
  */
-val WEATHER_PLANET_BASE_URL = "https://api2.sktelecom.com/weather"
+val WEATHER_PLANET_BASE_URL = "https://api2.sktelecom.com/weather/"

--- a/sk-weather-wrapper/build.gradle
+++ b/sk-weather-wrapper/build.gradle
@@ -1,35 +1,8 @@
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${rootProject.ext.versions.kotlin}"
-    }
-}
-
-group config.group
-version config.version
-
-apply plugin: 'kotlin'
-
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     compile deps.kotlinStdLib
     compile deps.retrofit
     compile deps.retrofitJacksonConverter
     compile deps.jacksonModuleKotlin
 
-    testCompile deps.junit
-    testCompile deps.assertj
     testCompile deps.okhttpMockWebServer
-}
-
-compileKotlin {
-    kotlinOptions.jvmTarget = "1.8"
-}
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.8"
 }


### PR DESCRIPTION
testSets 플러그인을 이용하여 integrationTest task와 관련 configuration을 추가하였다.
작업 중 gradle 관련 설정도 같이 최적화되었다.

작업 마지막에 weather-planet-wrapper 라이브러리에서 테스트가 실패하였다.
baseUrl의 마지막에 `/` 가 빠져있어서 넣어주었다.

각 작업들을 분리해야 하나 PR에 메모를 남기는 것으로 대체한다.